### PR TITLE
Add an onKeyDown prop to allow custom shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Here are the list of properties available for the component:
 - `initialValue` (number) the default value to show. Default 0.
 - `className` (string) the class name to apply to the DOM element. Default empty.
 - `onValueChange` (function) The callback when the value changes. The value is passed as the parameter.
+-  onKeyDown (function) This callback is called when a key is pressed, after the control has processed the key press, and allows developers to implement their own shortcuts, etc.
 
 ## demo
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -7,11 +7,16 @@ var fs = require('fs');
 var style = fs.readFileSync(__dirname+'/style.css', 'utf8');
 require('insert-css')(style);
 
+var KEYS = {
+    K: 75,
+    M: 77
+};
 
 class Demo extends React.Component {
     constructor() {
         super();
         this._onNumberChange = this._onNumberChange.bind(this);
+        this._onKeyDown = this._onKeyDown.bind(this);
 
         this.state = {
             numberValue: 0
@@ -29,16 +34,29 @@ class Demo extends React.Component {
             <div>
                 <NumberEditor
                     className="spinner"
-                    max={10}
-                    min={0}
+                    max={10000}
+                    min={-10}
                     decimals={2}
                     onValueChange={this._onNumberChange}
                     step={0.1}
                     value={this.state.numberValue}
+                    onKeyDown={this._onKeyDown}
+                    ref="demo-spinner"
                 />
                 <div>Value: {this.state.numberValue}</div>
+                <p>This control implements onKeyDown. Pressing 'k' will multiply the value by 1,000 and pressing 'm' will multiply the value by 1,000,000.</p>
             </div>
         );
+    }
+
+    _onKeyDown(e) {
+        var key = e.which;
+        var value = this.state.numberValue;
+        if(key === KEYS.K) {
+            this._onNumberChange(value * 1000);
+        } else if(key === KEYS.M) {
+            this._onNumberChange(value * 1000000);
+        }
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -8,8 +8,36 @@ var objectAssign = require('react/lib/Object.assign');
 var KEYS = {
     UP: 38,
     DOWN: 40,
-    ENTER: 13
+    ENTER: 13,
+    BACKSPACE: 8
 };
+
+// Allowed keys in the number editor:
+//   - Backspace
+//   - Tab
+//   - End
+//   - Home
+//   - Left Arrow
+//   - Right Arrow
+//   - Delete
+//   - 0 - 9
+//   - . (Dot)
+//   - - (Minus) [Multiple values across different browsers]
+//   - Numpad 0-9
+//   - Numpad - (Minus)
+var ALLOWED_KEYS = [8,
+                    9,
+                    35,
+                    36,
+                    37,
+                    39,
+                    46,
+                    48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+                    190,
+                    189, 173,
+                    96, 97, 98, 99, 100, 101, 102, 103, 104, 105,
+                    109
+];
 
 var NumberEditor = React.createClass({
     propTypes: {
@@ -24,7 +52,8 @@ var NumberEditor = React.createClass({
         value: React.PropTypes.oneOfType([
           React.PropTypes.string,
           React.PropTypes.number
-        ]).isRequired
+        ]).isRequired,
+        onKeyDown: React.PropTypes.func
     },
 
     getDefaultProps: function() {
@@ -106,7 +135,19 @@ var NumberEditor = React.createClass({
                 this.setState({
                     startEditing: true
                 });
+                e.target.select();
             }
+        }
+        else if(key === KEYS.BACKSPACE && !this.state.startEditing) {
+            e.preventDefault();
+        }
+        else if(ALLOWED_KEYS.indexOf(key) === -1) {
+            // Suppress any key we are not allowing.
+            e.preventDefault();
+        }
+
+        if(this.props.onKeyDown) {
+            this.props.onKeyDown(e);
         }
     },
 

--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "react-clickdrag": "^2.0.0"
   },
   "devDependencies": {
+    "babelify": "^5.0.4",
     "brfs": "^1.4.0",
-    "insert-css": "^0.2.0",
-    "babelify": "^5.0.4"
+    "browserify": "^11.2.0",
+    "insert-css": "^0.2.0"
   },
   "peerDependencies": {
     "react": ">=0.13"


### PR DESCRIPTION
- Added the ability to use 'k' and 't' to multiply value by 1000
  and 'm' to multiply value by 1000000.
- Limit the valid keys that can be used on number editor to prevent
  entry of non-numeric characters.